### PR TITLE
[trigger] Remove redundant check for self-authorship

### DIFF
--- a/trigger/trigger.py
+++ b/trigger/trigger.py
@@ -482,9 +482,6 @@ class Trigger:
         if message.server is None:
             return
 
-        if author == self.bot.user:
-            return
-
         if not self.bot.user_allowed(message):
             return
 


### PR DESCRIPTION
`bot.user_allowed(message)` already does this