### PR TITLE
:pencil: Minor text fix (grammar)

### DIFF
--- a/rift/rift.py
+++ b/rift/rift.py
@@ -10,7 +10,7 @@ OpenRift = namedtuple("Rift", ["source", "destination"])
 
 
 class Rift:
-    """Communicate with others servers/channels!"""
+    """Communicate with other servers/channels!"""
 
     def __init__(self, bot):
         self.bot = bot


### PR DESCRIPTION
Other is followed by noun while others is a pronoun and not followed by noun